### PR TITLE
feat: dogstagram post list query, api 구현 및 return-fetch 환경 셋팅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "react-hook-form": "^7.51.1",
         "react-intersection-observer": "^9.8.1",
         "react-textarea-autosize": "^8.5.3",
-        "recoil": "^0.7.7"
+        "recoil": "^0.7.7",
+        "return-fetch": "^0.4.5"
       },
       "devDependencies": {
         "@mswjs/http-middleware": "^0.9.1",
@@ -9300,6 +9301,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/return-fetch": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/return-fetch/-/return-fetch-0.4.5.tgz",
+      "integrity": "sha512-B4dEbp7cjVuXE0EshS4skHfCdGKYA2U1XDGRCa8EhE6P+R+tAmMtfVskeOI4CAyryD3HNz1esvFGKxOwq4VOhw==",
+      "hasInstallScript": true
     },
     "node_modules/reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-hook-form": "^7.51.1",
     "react-intersection-observer": "^9.8.1",
     "react-textarea-autosize": "^8.5.3",
-    "recoil": "^0.7.7"
+    "recoil": "^0.7.7",
+    "return-fetch": "^0.4.5"
   },
   "devDependencies": {
     "@mswjs/http-middleware": "^0.9.1",
@@ -39,9 +40,9 @@
     "cors": "^2.8.5",
     "eslint": "^8",
     "eslint-config-next": "14",
+    "msw": "^2.0.0",
     "react-select": "^5.8.0",
-    "typescript": "^5",
-    "msw": "^2.0.0"
+    "typescript": "^5"
   },
   "msw": {
     "workerDirectory": "public"

--- a/src/app/(commons)/_component/RQProvider.tsx
+++ b/src/app/(commons)/_component/RQProvider.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import React, { useState } from "react";
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+type Props = {
+  children: React.ReactNode;
+};
+
+function RQProvider({ children }: Props) {
+  const [client] = useState(
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          refetchOnWindowFocus: false,
+          retryOnMount: true,
+          refetchOnReconnect: false,
+          retry: false,
+        },
+      },
+    })
+  );
+
+  return (
+    <QueryClientProvider client={client}>
+      {children}
+      <ReactQueryDevtools
+        initialIsOpen={process.env.NEXT_PUBLIC_MODE === "local"}
+      />
+    </QueryClientProvider>
+  );
+}
+
+export default RQProvider;

--- a/src/app/(route)/layout.tsx
+++ b/src/app/(route)/layout.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import { ReactNode } from "react";
 import Header from "../(commons)/_component/Header";
 import RecoilRootProvider from "../(commons)/_component/RecoilProvider";
+import RQProvider from "../(commons)/_component/RQProvider";
 import * as styles from "./main.css";
 
 export const metadata: Metadata = {
@@ -14,9 +15,11 @@ export default function Layout({ children, modal }: Props) {
   return (
     <div className={styles.container}>
       <RecoilRootProvider>
-        <Header />
-        {modal}
-        {children}
+        <RQProvider>
+          <Header />
+          {modal}
+          {children}
+        </RQProvider>
       </RecoilRootProvider>
     </div>
   );

--- a/src/app/_apis/commonsApi.ts
+++ b/src/app/_apis/commonsApi.ts
@@ -4,10 +4,6 @@ export const fetchExtended = returnFetch({
   baseUrl: process.env.NEXT_PUBLIC_BASE_URL,
   headers: { Accept: "application/json" },
   interceptors: {
-    // request: async (args) => {
-    //   return args;
-    // },
-
     response: async (response) => {
       return response;
     },

--- a/src/app/_apis/commonsApi.ts
+++ b/src/app/_apis/commonsApi.ts
@@ -1,0 +1,15 @@
+import returnFetch from "return-fetch";
+
+export const fetchExtended = returnFetch({
+  baseUrl: process.env.NEXT_PUBLIC_BASE_URL,
+  headers: { Accept: "application/json" },
+  interceptors: {
+    // request: async (args) => {
+    //   return args;
+    // },
+
+    response: async (response) => {
+      return response;
+    },
+  },
+});

--- a/src/app/_apis/dogStagram/getDogStagramPostList.ts
+++ b/src/app/_apis/dogStagram/getDogStagramPostList.ts
@@ -1,0 +1,18 @@
+import { DogStagramPostListType } from "@/app/_types/dogStagram";
+import { fetchExtended } from "../commonsApi";
+
+export const getDogStagramPostList = async (): Promise<
+  DogStagramPostListType[]
+> => {
+  try {
+    const response = await fetchExtended("/dogstagram", {
+      method: "GET",
+    });
+    const { data } = await response.json();
+
+    return data;
+  } catch (error) {
+    console.error("Error fetching DogStagram post list:", error);
+    throw error;
+  }
+};

--- a/src/app/_service/dogStagram/useGetDogStagramPostList.ts
+++ b/src/app/_service/dogStagram/useGetDogStagramPostList.ts
@@ -1,0 +1,19 @@
+import { DogStagramPostListType } from "@/app/_types/dogStagram";
+import { QueryKey, useQuery } from "@tanstack/react-query";
+import { getDogStagramPostList } from "../../_apis/dogStagram/getDogStagramPostList";
+
+export const useGetDogStagramPostList = () => {
+  const { data: dogStagramPostList } = useQuery<
+    DogStagramPostListType[],
+    Object,
+    DogStagramPostListType[],
+    QueryKey
+  >({
+    queryKey: ["dogstagramPostList"],
+    queryFn: getDogStagramPostList,
+    staleTime: 60 * 1000,
+    gcTime: 300 * 1000,
+  });
+
+  return { dogStagramPostList };
+};

--- a/src/app/_types/dogStagram.ts
+++ b/src/app/_types/dogStagram.ts
@@ -1,0 +1,11 @@
+export interface DogStagramPostListType {
+  id: number;
+  user_id: number;
+  nickname: string;
+  description: string;
+  image_url: string[];
+  is_liked: boolean;
+  total_like: number;
+  last_liked_user: string;
+  created_at: Date;
+}

--- a/src/app/_types/reactQuery.ts
+++ b/src/app/_types/reactQuery.ts
@@ -1,0 +1,1 @@
+export type QueryKey = string[] | readonly unknown[];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,11 +1,25 @@
 import { http, HttpResponse } from "msw";
 
-export const handlers = [
-  http.get(`${process.env.NEXT_PUBLIC_BASE_URL}/api/users`, () => {
-    return HttpResponse.json({
-      data: {
-        name: "kimjiwoo",
-      },
+export const handlers = Array.from({ length: 100 }, () => {
+  return http.get(`${process.env.NEXT_PUBLIC_BASE_URL}/dogstagram`, () => {
+    const dogData = (index: number) => ({
+      id: `dog${index}`,
+      user_id: `user${index}`,
+      nickname: `nickname${index}`,
+      description: `so cute ${index}`,
+      image_url: [
+        "https://images.dog.ceo//breeds//retriever-chesapeake//n02099849_3037.jpg",
+        "https://images.dog.ceo//breeds//akita//An_Akita_Inu_resting.jpg",
+        "https://images.dog.ceo//breeds//poodle-toy//n02113624_253.jpg",
+      ],
+      is_liked: index % 2 === 0 ? true : false,
+      total_like: index,
+      last_liked_user: `user${index}`,
+      created_at: "2023-03-01",
     });
-  }),
-];
+
+    return HttpResponse.json({
+      data: Array.from({ length: 100 }, (_, index) => dogData(index)),
+    });
+  });
+});


### PR DESCRIPTION
### PR 타입
-[feat] : dogstagram post list query, api 구현 및 return-fetch 환경 셋팅

### 구현 사항
- return-fetch 라이브러리 설치 
- return-fetch commons api 생성
- react-query provider 생성 및 전역 설정 
- dogstagram post list query 및 api 호출 구현
- dogstagram post list mocking 생성