### PR TITLE
refactor: access token 유무에 따른 로직 변경

### DIFF
--- a/src/app/(commons)/_component/Header.tsx
+++ b/src/app/(commons)/_component/Header.tsx
@@ -11,7 +11,7 @@ import * as styles from "./_style/header.css";
 export default function Header() {
   const router = useRouter();
   const pathname = usePathname();
-  const isAccessToken = token.get(ACCESS_TOKEN) !== null ? false : true;
+  const isAccessToken = token.get(ACCESS_TOKEN) !== null ? true : false;
 
   const handleClick: MouseEventHandler<HTMLButtonElement> = (e) => {
     router.push(e.currentTarget.getAttribute("data-url") || "");
@@ -30,11 +30,14 @@ export default function Header() {
         <Image src={"/mainlogo.png"} width={103} height={31} alt="profile" />
         <div className={styles.menuContainer}>
           <LinkButton text="채팅" onClick={handleClick} url="/chat" />
-          <LinkButton text="내 정보" onClick={handleClick} url="/profile" />
+
           {isAccessToken ? (
-            <LinkButton text="로그인" onClick={handleClick} url="/signin" />
+            <>
+              <LinkButton text="내 정보" onClick={handleClick} url="/profile" />
+              <LinkButton text="로그아웃" onClick={handleSignOut} />
+            </>
           ) : (
-            <LinkButton text="로그아웃" onClick={handleSignOut} />
+            <LinkButton text="로그인" onClick={handleClick} url="/signin" />
           )}
         </div>
       </header>

--- a/src/app/_apis/dogStagram/getDogStagramPostList.ts
+++ b/src/app/_apis/dogStagram/getDogStagramPostList.ts
@@ -1,6 +1,8 @@
+import { ACCESS_TOKEN } from "@/app/_const/const";
 import { API_URL } from "@/app/_const/url";
 import { DogStagramPostListType } from "@/app/_types/dogStagram";
-import { noAuthfetchExtended } from "../commonsApi";
+import token from "@/app/_utils/token";
+import { noAuthfetchExtended, fetchExtended } from "../commonsApi";
 
 interface Props {
   pageParam?: number;
@@ -12,16 +14,27 @@ export const getDogStagramPostList = async ({
   searchDogType,
 }: Props): Promise<DogStagramPostListType[]> => {
   try {
-    const response = await noAuthfetchExtended(
-      `${API_URL.GET.DOGSTAGRAM}/search?search_word=${searchDogType}&take=10&skip=${pageParam}`,
-      {
-        method: "GET",
-      }
-    );
+    if (token.get(ACCESS_TOKEN) !== null) {
+      const response = await fetchExtended(
+        `${API_URL.GET.DOGSTAGRAM}/search?search_word=${searchDogType}&take=10&skip=${pageParam}`,
+        {
+          method: "GET",
+        }
+      );
 
-    const data = await response.json();
+      const data = await response.json();
+      return data;
+    } else {
+      const response = await noAuthfetchExtended(
+        `${API_URL.GET.DOGSTAGRAM}/search?search_word=${searchDogType}&take=10&skip=${pageParam}`,
+        {
+          method: "GET",
+        }
+      );
 
-    return data;
+      const data = await response.json();
+      return data;
+    }
   } catch (error) {
     console.error("Error fetching DogStagram post list:", error);
     throw error;

--- a/src/app/_apis/dogStagram/getStarDogPostList.ts
+++ b/src/app/_apis/dogStagram/getStarDogPostList.ts
@@ -1,17 +1,29 @@
+import { fetchExtended } from "@/app/_apis/commonsApi";
 import { API_URL } from "./../../_const/url";
 import { StarDogStagramPostListType } from "@/app/_types/dogStagram";
 import { noAuthfetchExtended } from "../commonsApi";
+import { ACCESS_TOKEN } from "@/app/_const/const";
+import token from "@/app/_utils/token";
 
 export const getStarDogPostList = async (): Promise<
   StarDogStagramPostListType[]
 > => {
   try {
-    const response = await noAuthfetchExtended(API_URL.GET.STAR_DOGSTGRAM, {
-      method: "GET",
-    });
-    const data = await response.json();
+    if (token.get(ACCESS_TOKEN) !== null) {
+      const response = await fetchExtended(API_URL.GET.STAR_DOGSTGRAM, {
+        method: "GET",
+      });
 
-    return data;
+      const data = await response.json();
+      return data;
+    } else {
+      const response = await noAuthfetchExtended(API_URL.GET.STAR_DOGSTGRAM, {
+        method: "GET",
+      });
+
+      const data = await response.json();
+      return data;
+    }
   } catch (error) {
     console.error("Error fetching StarDogStagram post list:", error);
     throw error;

--- a/src/app/_apis/profile/getUserProfile.ts
+++ b/src/app/_apis/profile/getUserProfile.ts
@@ -1,9 +1,12 @@
 import { API_URL } from "../../_const/url";
 import { fetchExtended } from "../commonsApi";
 import { ProfileAllInfo } from "@/app/_types/profile";
+import { ACCESS_TOKEN } from "@/app/_const/const";
+import token from "@/app/_utils/token";
 
-export const getUserProfile = async (): Promise<ProfileAllInfo> => {
+export const getUserProfile = async (): Promise<ProfileAllInfo | null> => {
   try {
+    if (token.get(ACCESS_TOKEN) === null) return null;
     const response = await fetchExtended(API_URL.GET.PROFILE, {
       method: "GET",
     });


### PR DESCRIPTION
### PR 타입
-[refactor] : access token 유무에 따른 로직 변경

### 구현 사항
- access token 유무에 따른 로직 변경
-> 견스타그램 조회 api return fetch auth / noauth 분리
-> header 내 정보 링크 컴포넌트 숨김처리